### PR TITLE
typo in readme + add repo link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change log
+
+### 1.0.2 - 2015-10-08
+- documentation typo
+- add repo link
+
+### 1.0.0
+- initial release
+

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# time-select
+# react-time-select
 
 [React](https://facebook.github.io/react/) Component to render a [React Bootstrap](https://react-bootstrap.github.io/) dropdown list pre-filled with localizable times formatted by [ReactIntl](http://formatjs.io/react/).
 
 ```
-var TimeSelect = require('time-select');
+var TimeSelect = require('react-time-select');
 React.render(<TimeSelect label="Choose time" />, document.getElementById('container'));
 ```
 
@@ -27,4 +27,4 @@ Clone the repo and `npm install`.
 
 `npm test` for the unit tests.
 
-`npm lint` checks the code against our [guidelines](https://github.com/holidayextras/culture/blob/master/.eslintrc)
+`npm run lint` checks the code against our [guidelines](https://github.com/holidayextras/culture/blob/master/.eslintrc)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-time-select",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Component to generate a dropdown list populated with a configurable time range",
   "main": "src/TimeSelect.jsx",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-time-select",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Component to generate a dropdown list populated with a configurable time range",
   "main": "src/TimeSelect.jsx",
   "scripts": {
@@ -11,6 +11,10 @@
   },
   "author": "Ollie Buck <ollie.buck@holidayextras.com>",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/holidayextras/react-time-select.git"
+  },
   "dependencies": {
     "react": "^0.13.3",
     "react-bootstrap": "^0.25.2",


### PR DESCRIPTION
looks like you changed the name at some point, the README now reflects this
also added a repo link, clears a warning on `npm install`
push this if it's acceptable so the docs on https://www.npmjs.com/package/react-time-select are right
