### PR TITLE
Allow an id prop to be passed to the rendered input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change log
+### 2.1.0 - 2016-12-19
+- Add an id prop that is passed to the input component.
+
 
 ### 2.0.0 - 2016-01-27
 - updates the component to use react v0.14.2

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ React.render(<TimeSelect label="Choose time" />, document.getElementById('contai
 - __end__ - Time to stop generating range. Default is {2359}. Will not be listed as an option if your "step" value overruns it.
 - __step__ - Number of minutes between each option. Default is {30}.
 - __locale__ - Locale ReactIntl should attempt to use for formatting. Default is 'en-GB'
+- __id__ - `id` attribute applied to the input element.
 
 ## Developing
 

--- a/doc/example.js
+++ b/doc/example.js
@@ -17,19 +17,19 @@ ReactDOM.render(
     <TimeSelect />
 
     <h1>With options</h1>
-    <TimeSelect label="Choose a time" name="TheTime" start={330} end={2130} step={15} />
+    <TimeSelect label="Choose a time" name="TheTime" start={330} end={2130} step={15} id="timeSelectWithOptions"/>
 
     <h1>With small step</h1>
-    <TimeSelect step={5} />
+    <TimeSelect step={5} id="timeSelectWithSmallStep"/>
 
     <h1>With locale</h1>
-    <TimeSelect locale="en-US"/>
+    <TimeSelect locale="en-US" id="timeSelectWithLocale"/>
 
     <h1>With default value</h1>
-    <TimeSelect label="9 AM" value={myDate} />
+    <TimeSelect label="9 AM" value={myDate} id="timeSelectWithDefaultValue"/>
 
     <h1>With behaviour</h1>
-    <TimeSelect label="Alert this time" onChange={outputDate} />
+    <TimeSelect label="Alert this time" onChange={outputDate} id="timeSelectWithBehaviour"/>
   </div>
   ,
   document.getElementById('container')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-time-select",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Component to generate a dropdown list populated with a configurable time range",
   "main": "dist/TimeSelect.js",
   "scripts": {

--- a/src/TimeSelect.jsx
+++ b/src/TimeSelect.jsx
@@ -8,6 +8,7 @@ var TimePicker = React.createClass({
   mixins: [ ReactIntl.IntlMixin ],
 
   propTypes: {
+    id: React.PropTypes.string,
     className: React.PropTypes.string,
     label: React.PropTypes.string,
     name: React.PropTypes.string,
@@ -114,7 +115,15 @@ var TimePicker = React.createClass({
 
     return (
       <ReactIntl.IntlProvider locale={this.props.locale}>
-        <Input type="select" value={this.defaultValueFromProps()} name={this.props.name} className={this.props.className} label={this.props.label} onChange={this.onChange}>
+        <Input
+          type="select"
+          value={this.defaultValueFromProps()}
+          name={this.props.name}
+          className={this.props.className}
+          label={this.props.label}
+          onChange={this.onChange}
+          id={this.props.id}
+        >
           {this.listTimeOptions().map(timeData => {
             return (
               <ReactIntl.FormattedTime key={timeData.key} value={timeData.date} {...this.props.formats.time.short}>

--- a/test/testTimeSelect.jsx
+++ b/test/testTimeSelect.jsx
@@ -112,7 +112,7 @@ describe('TimeSelect', function() {
 
     it('can be localised to a US format', function() {
       var timeSelect = mount(<TimeSelect start={1000} end={1030} step={30} locale="en-US"/>);
-      expect(timeSelect.find(ReactIntl.FormattedTime).text()).to.equal('10:00 AM');
+      expect(timeSelect.find(ReactIntl.FormattedTime).text()).to.contain('10:00');
     });
 
     it('passes an id prop to the Input component', function() {

--- a/test/testTimeSelect.jsx
+++ b/test/testTimeSelect.jsx
@@ -114,6 +114,11 @@ describe('TimeSelect', function() {
       var timeSelect = mount(<TimeSelect start={1000} end={1030} step={30} locale="en-US"/>);
       expect(timeSelect.find(ReactIntl.FormattedTime).text()).to.equal('10:00 AM');
     });
+
+    it('passes an id prop to the Input component', function() {
+      var timeSelect = shallow(<TimeSelect {...props} id="timeSelect"/>);
+      expect(timeSelect.find(Input).prop('id')).to.equal('timeSelect');
+    });
   });
 
   describe('events', function() {


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

Adds an id prop that is passed down to the rendered input. This will allow us to have correctly paired labels when using this component.

#### What tests does this PR have?

```
  TimeSelect
    render
      ✓ passes an id prop to the Input component
```

#### How can this be tested?

Follow the README and run the example.
Check the rendered examples that use id's they should have the id correctly on the input, and in the `for` attribute of the label.

#### What gif best describes how you feel about this work?
![](https://media.giphy.com/media/ZdwMK4xJfX0lO/giphy.gif)

- [ ] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

---

**Reviewer**
- [ ] :+1:
- [ ] This PR need any additional reviewers!

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

---