### PR TITLE
Prod 1641 - Add support for seperate hour / minute dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change log
+
+### 2.2.0 - 2017-02-24
+- Added a seperateHourMins prop that allows for individual hour and minute inputs. 
+
 ### 2.1.0 - 2016-12-19
 - Add an id prop that is passed to the input component.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change log
 
 ### 2.2.0 - 2017-02-24
-- Added a seperateHourMins prop that allows for individual hour and minute inputs. 
+- Add a seperateHourMins prop that allows for individual hour and minute inputs. 
+- Add a time prop that passes hour / minute values to hour / minute inputs.
 
 ### 2.1.0 - 2016-12-19
 - Add an id prop that is passed to the input component.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ React.render(<TimeSelect label="Choose time" />, document.getElementById('contai
 - __step__ - Number of minutes between each option. Default is {30}.
 - __locale__ - Locale ReactIntl should attempt to use for formatting. Default is 'en-GB'
 - __id__ - `id` attribute applied to the input element.
+- __seperateHourMins__ - Toggle for splitting hour and minutes into seperate inputs. Default is 'false'.
+- __time__ - Object with 'hours' and 'minutes' for specifying current hour / minute input values.
 
 ## Developing
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "ci": "npm run lint && npm run coverage",
     "coverage": "istanbul cover _mocha -- --compilers js:babel/register --require react-tests-globals-setup test/test* && istanbul check-coverage --statements 95 --branches 95 --functions 95 --lines 95",
-    "prepublish": "mkdir -p dist && babel src/TimeSelect.jsx > dist/TimeSelect.js",
+    "prepublish": "mkdir -p dist && babel src/TimeSelect.jsx > dist/TimeSelect.js && babel src/HourInput.jsx > dist/HourInput.js && babel src/MinuteInput.jsx > dist/MinuteInput.js && babel src/TimeInput.jsx > dist/TimeInput.js",
     "prestart": "ulimit -n 9999",
     "start": "watchify -t babelify doc/example.js -o doc/example-built.js -v",
     "test": "mocha --compilers js:babel/register --require react-tests-globals-setup test/test*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-time-select",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Component to generate a dropdown list populated with a configurable time range",
   "main": "dist/TimeSelect.js",
   "scripts": {

--- a/src/HourInput.jsx
+++ b/src/HourInput.jsx
@@ -1,0 +1,30 @@
+'use strict';
+
+var React = require('react');
+var TimeInput = require('./TimeInput');
+
+var HourInput = React.createClass({
+  propTypes: {
+    id: React.PropTypes.string,
+    className: React.PropTypes.string,
+    name: React.PropTypes.string,
+    value: React.PropTypes.instanceOf(Date),
+    onChange: React.PropTypes.func,
+    options: React.PropTypes.object
+  },
+
+  render: function() {
+    return (
+      <TimeInput
+        id={this.props.id}
+        value={this.props.value}
+        className={this.props.className}
+        containerClassName="col-xs-6"
+        label="Hours"
+        options={this.props.options}
+        onChange={this.props.onChange} />
+    );
+  }
+});
+
+module.exports = HourInput;

--- a/src/MinuteInput.jsx
+++ b/src/MinuteInput.jsx
@@ -1,0 +1,30 @@
+'use strict';
+
+var React = require('react');
+var TimeInput = require('./TimeInput');
+
+var MinuteInput = React.createClass({
+  propTypes: {
+    id: React.PropTypes.string,
+    className: React.PropTypes.string,
+    name: React.PropTypes.string,
+    value: React.PropTypes.instanceOf(Date),
+    onChange: React.PropTypes.func,
+    options: React.PropTypes.object
+  },
+
+  render: function() {
+    return (
+      <TimeInput
+        id={this.props.id}
+        value={this.props.value}
+        className={this.props.className}
+        containerClassName="col-xs-6"
+        label="Minutes"
+        options={this.props.options}
+        onChange={this.props.onChange} />
+    );
+  }
+});
+
+module.exports = MinuteInput;

--- a/src/TimeInput.jsx
+++ b/src/TimeInput.jsx
@@ -1,0 +1,41 @@
+'use strict';
+
+var React = require('react');
+var Input = require('react-bootstrap').Input;
+
+var TimeInput = React.createClass({
+  propTypes: {
+    id: React.PropTypes.string,
+    className: React.PropTypes.string,
+    containerClassName: React.PropTypes.string,
+    label: React.PropTypes.string,
+    name: React.PropTypes.string,
+    value: React.PropTypes.instanceOf(Date),
+    options: React.PropTypes.object,
+    onChange: React.PropTypes.func
+  },
+
+  render: function() {
+    return (
+      <div className={this.props.containerClassName}>
+        <Input
+          type="select"
+          value={this.props.value}
+          name={this.props.name}
+          className={this.props.className}
+          label={this.props.label}
+          onChange={this.props.onChange}
+          id={this.props.id}
+        >
+          {this.props.options.map(option => {
+            return (
+              <option value={option}>{option}</option>
+            );
+          })}
+        </Input>
+      </div>
+    );
+  }
+});
+
+module.exports = TimeInput;

--- a/src/TimeSelect.jsx
+++ b/src/TimeSelect.jsx
@@ -141,11 +141,13 @@ var TimePicker = React.createClass({
   },
 
   changeCombinedTime: function(e) {
-    var hourMins = e.target.value.split(':');
-    this.props.onChange({
-      hours: hourMins[0],
-      minutes: hourMins[1]
-    });
+    if (this.props.onChange) {
+      var hourMins = e.target.value.split(':');
+      this.props.onChange({
+        hours: hourMins[0],
+        minutes: hourMins[1]
+      });
+    }
   },
 
   changeHours: function(e) {
@@ -172,7 +174,7 @@ var TimePicker = React.createClass({
             id={this.props.id}
             className={this.props.className}
             value={this.props.time.hours}
-            name={this.props.time.hours}
+            name="hours"
             onChange={this.changeHours}
             options={this.generateHours()} />
 
@@ -180,7 +182,7 @@ var TimePicker = React.createClass({
             id={this.props.id}
             className={this.props.className}
             value={this.props.time.minutes}
-            name={this.props.name}
+            name="minutes"
             onChange={this.changeMinutes}
             options={this.generateMinutes()} />
         </div>

--- a/test/testHourInput.jsx
+++ b/test/testHourInput.jsx
@@ -6,7 +6,6 @@ var expect = require('chai')
   .use(require('dirty-chai')).expect;
 
 var assert = require('assert');
-var sinon = require('sinon');
 var { shallow } = require('enzyme');
 
 var HourInput = require('../src/HourInput');
@@ -23,7 +22,7 @@ describe('HourInput', function() {
     };
   });
 
-  it('is an element', function () {
+  it('is an element', function() {
     assert(TestUtils.isElement(<HourInput />));
   });
 

--- a/test/testHourInput.jsx
+++ b/test/testHourInput.jsx
@@ -1,0 +1,56 @@
+'use strict';
+
+var React = require('react');
+var TestUtils = require('react-addons-test-utils');
+var expect = require('chai')
+  .use(require('dirty-chai')).expect;
+
+var assert = require('assert');
+var sinon = require('sinon');
+var { shallow } = require('enzyme');
+
+var HourInput = require('../src/HourInput');
+var TimeInput = require('../src/TimeInput');
+
+describe('HourInput', function() {
+  var props;
+
+  beforeEach(function() {
+    props = {
+      className: 'input-sm',
+      options: ['1', '2', '3'],
+      value: new Date()
+    };
+  });
+
+  it('is an element', function () {
+    assert(TestUtils.isElement(<HourInput />));
+  });
+
+  describe('render', function() {
+    it('should render an TimeInput field', function() {
+      var hourInput = shallow(<HourInput {...props} />);
+      expect(hourInput.find(TimeInput)).to.have.length(1);
+    });
+
+    it('should render an TimeInput field with label hours', function() {
+      var hourInput = shallow(<HourInput {...props} />);
+      expect(hourInput.find(TimeInput).props().label).to.equal('Hours');
+    });
+
+    it('should render an TimeInput field with a className prop', function() {
+      var hourInput = shallow(<HourInput {...props} />);
+      expect(hourInput.find(TimeInput).props().className).to.equal(props.className);
+    });
+
+    it('should render an TimeInput field with a value prop', function() {
+      var hourInput = shallow(<HourInput {...props} />);
+      expect(hourInput.find(TimeInput).props().value).to.equal(props.value);
+    });
+
+    it('should render an TimeInput field with a value prop', function() {
+      var hourInput = shallow(<HourInput {...props} />);
+      expect(hourInput.find(TimeInput).props().options).to.equal(props.options);
+    });
+  });
+});

--- a/test/testMinuteInput.jsx
+++ b/test/testMinuteInput.jsx
@@ -1,0 +1,56 @@
+'use strict';
+
+var React = require('react');
+var TestUtils = require('react-addons-test-utils');
+var expect = require('chai')
+  .use(require('dirty-chai')).expect;
+
+var assert = require('assert');
+var sinon = require('sinon');
+var { shallow } = require('enzyme');
+
+var MinuteInput = require('../src/MinuteInput');
+var TimeInput = require('../src/TimeInput');
+
+describe('MinuteInput', function() {
+  var props;
+
+  beforeEach(function() {
+    props = {
+      className: 'input-sm',
+      options: ['5', '10', '15'],
+      value: new Date()
+    };
+  });
+
+  it('is an element', function () {
+    assert(TestUtils.isElement(<MinuteInput />));
+  });
+
+  describe('render', function() {
+    it('should render an TimeInput field', function() {
+      var minuteInput = shallow(<MinuteInput {...props} />);
+      expect(minuteInput.find(TimeInput)).to.have.length(1);
+    });
+
+    it('should render an TimeInput field with label hours', function() {
+      var minuteInput = shallow(<MinuteInput {...props} />);
+      expect(minuteInput.find(TimeInput).props().label).to.equal('Minutes');
+    });
+
+    it('should render an TimeInput field with a className prop', function() {
+      var minuteInput = shallow(<MinuteInput {...props} />);
+      expect(minuteInput.find(TimeInput).props().className).to.equal(props.className);
+    });
+
+    it('should render an TimeInput field with a value prop', function() {
+      var minuteInput = shallow(<MinuteInput {...props} />);
+      expect(minuteInput.find(TimeInput).props().value).to.equal(props.value);
+    });
+
+    it('should render an TimeInput field with a value prop', function() {
+      var minuteInput = shallow(<MinuteInput {...props} />);
+      expect(minuteInput.find(TimeInput).props().options).to.equal(props.options);
+    });
+  });
+});

--- a/test/testMinuteInput.jsx
+++ b/test/testMinuteInput.jsx
@@ -6,7 +6,6 @@ var expect = require('chai')
   .use(require('dirty-chai')).expect;
 
 var assert = require('assert');
-var sinon = require('sinon');
 var { shallow } = require('enzyme');
 
 var MinuteInput = require('../src/MinuteInput');
@@ -23,7 +22,7 @@ describe('MinuteInput', function() {
     };
   });
 
-  it('is an element', function () {
+  it('is an element', function() {
     assert(TestUtils.isElement(<MinuteInput />));
   });
 

--- a/test/testTimeInput.jsx
+++ b/test/testTimeInput.jsx
@@ -1,0 +1,58 @@
+'use strict';
+
+var React = require('react');
+var TestUtils = require('react-addons-test-utils');
+var expect = require('chai')
+  .use(require('dirty-chai')).expect;
+
+var Input = require('react-bootstrap').Input;
+
+var assert = require('assert');
+var sinon = require('sinon');
+var { shallow } = require('enzyme');
+
+var TimeInput = require('../src/TimeInput');
+
+describe('TimeInput', function() {
+  var props;
+
+  beforeEach(function() {
+    props = {
+      className: 'input-sm',
+      label: 'Time',
+      options: ['1', '2', '3'],
+      value: new Date()
+    };
+  });
+
+  it('is an element', function () {
+    assert(TestUtils.isElement(<TimeInput />));
+  });
+
+  describe('render', function() {
+    it('should render an Input field', function() {
+      var timeInput = shallow(<TimeInput {...props} />);
+      expect(timeInput.find(Input)).to.have.length(1);
+    });
+
+    it('should render an Input field with type select', function() {
+      var timeInput = shallow(<TimeInput {...props} />);
+      expect(timeInput.find(Input).props().type).to.equal('select');
+    });
+
+    it('should render an Input field with a className prop', function() {
+      var timeSelect = shallow(<TimeInput {...props} />);
+      expect(timeSelect.find(Input).props().className).to.equal(props.className);
+    });
+
+    it('should render an Input field with a value prop', function() {
+      var timeSelect = shallow(<TimeInput {...props} />);
+      expect(timeSelect.find(Input).props().value).to.equal(props.value);
+    });
+
+    it('fills the select box with a range of times', function() {
+      var timeSelect = shallow(<TimeInput {...props} />);
+      expect(timeSelect.find(Input).children()).to.have.length(props.options.length);
+    });
+  });
+});

--- a/test/testTimeInput.jsx
+++ b/test/testTimeInput.jsx
@@ -8,7 +8,6 @@ var expect = require('chai')
 var Input = require('react-bootstrap').Input;
 
 var assert = require('assert');
-var sinon = require('sinon');
 var { shallow } = require('enzyme');
 
 var TimeInput = require('../src/TimeInput');
@@ -25,7 +24,7 @@ describe('TimeInput', function() {
     };
   });
 
-  it('is an element', function () {
+  it('is an element', function() {
     assert(TestUtils.isElement(<TimeInput />));
   });
 

--- a/test/testTimeSelect.jsx
+++ b/test/testTimeSelect.jsx
@@ -232,7 +232,7 @@ describe('TimeSelect', function() {
       context('hours', function() {
         it('will emit hours up if an option is chosen', function() {
           var handler = sinon.stub();
-          var doc = TestUtils.renderIntoDocument(<TimeSelect seperateHourMins={true} time={time} minutesHoursChanged={handler} />);
+          var doc = TestUtils.renderIntoDocument(<TimeSelect seperateHourMins={true} time={time} onChange={handler} />);
           var node = TestUtils.scryRenderedDOMComponentsWithTag(doc, 'select')[0];
 
           TestUtils.Simulate.change(node, {
@@ -248,7 +248,7 @@ describe('TimeSelect', function() {
       context('minutes', function() {
         it('will emit minutes up if an option is chosen', function() {
           var handler = sinon.stub();
-          var doc = TestUtils.renderIntoDocument(<TimeSelect seperateHourMins={true} time={time} minutesHoursChanged={handler} />);
+          var doc = TestUtils.renderIntoDocument(<TimeSelect seperateHourMins={true} time={time} onChange={handler} />);
           var node = TestUtils.scryRenderedDOMComponentsWithTag(doc, 'select')[1];
 
           TestUtils.Simulate.change(node, {

--- a/test/testTimeSelect.jsx
+++ b/test/testTimeSelect.jsx
@@ -31,6 +31,7 @@ describe('TimeSelect', function() {
         name: 'Time',
         label: 'Time',
         locale: 'en-GB',
+        seperateHourMins: false,
         formats: {
           time: {
             short: {
@@ -119,6 +120,50 @@ describe('TimeSelect', function() {
       var timeSelect = shallow(<TimeSelect {...props} id="timeSelect"/>);
       expect(timeSelect.find(Input).prop('id')).to.equal('timeSelect');
     });
+
+    context('seperateHourMins', function() {
+      beforeEach(function() {
+        props = {
+          time: {
+            hours: '10',
+            minutes: '5'
+          },
+          seperateHourMins: true
+        };
+      });
+
+      it('should create 2 inputs', function() {
+        var timeSelect = shallow(<TimeSelect {...props}/>);
+        expect(timeSelect.find(Input)).to.have.length(2);
+      });
+
+      it('should have a hours input', function() {
+        var timeSelect = shallow(<TimeSelect {...props}/>);
+        expect(timeSelect.find(Input).first().props().label).to.equal('Hours');
+      });
+
+      it('should have a minutes input', function() {
+        var timeSelect = shallow(<TimeSelect {...props}/>);
+        expect(timeSelect.find(Input).at(1).props().label).to.equal('Minutes');
+      });
+
+      it('should use current time as value', function() {
+        var timeSelect = shallow(<TimeSelect {...props}/>);
+        expect(timeSelect.find(Input).first().props().value).to.equal(props.time.hours);
+        expect(timeSelect.find(Input).at(1).props().value).to.equal(props.time.minutes);
+      });
+
+      it('fills the hours select box with 24 hours', function() {
+        var timeSelect = shallow(<TimeSelect {...props}/>);
+        expect(timeSelect.find(Input).first().children()).to.have.length(24);
+      });
+
+      it('fills the minutes select box with range from steps prop', function() {
+        props.step = 5;
+        var timeSelect = shallow(<TimeSelect {...props}/>);
+        expect(timeSelect.find(Input).at(1).children()).to.have.length(12);
+      });
+    });
   });
 
   describe('events', function() {
@@ -172,6 +217,49 @@ describe('TimeSelect', function() {
       });
 
       sinon.assert.calledWith(handler, new Date(2016, 7, 8, 14, 30, 0, 0));
+    });
+
+    context('seperateHourMins', function() {
+      var time;
+
+      beforeEach(function() {
+        time = {
+          hours: '11',
+          minutes: '55'
+        };
+      });
+
+      context('hours', function() {
+        it('will emit hours up if an option is chosen', function() {
+          var handler = sinon.stub();
+          var doc = TestUtils.renderIntoDocument(<TimeSelect seperateHourMins={true} time={time} minutesHoursChanged={handler} />);
+          var node = TestUtils.scryRenderedDOMComponentsWithTag(doc, 'select')[0];
+
+          TestUtils.Simulate.change(node, {
+            target: {
+              value: '14'
+            }
+          });
+
+          sinon.assert.calledWith(handler, { hours: '14' });
+        });
+      });
+
+      context('minutes', function() {
+        it('will emit minutes up if an option is chosen', function() {
+          var handler = sinon.stub();
+          var doc = TestUtils.renderIntoDocument(<TimeSelect seperateHourMins={true} time={time} minutesHoursChanged={handler} />);
+          var node = TestUtils.scryRenderedDOMComponentsWithTag(doc, 'select')[1];
+
+          TestUtils.Simulate.change(node, {
+            target: {
+              value: '50'
+            }
+          });
+
+          sinon.assert.calledWith(handler, { minutes: '50' });
+        });
+      });
     });
   });
 });

--- a/test/testTimeSelect.jsx
+++ b/test/testTimeSelect.jsx
@@ -6,6 +6,7 @@ var expect = require('chai')
 .use(require('dirty-chai')).expect;
 
 var Input = require('react-bootstrap').Input;
+
 var ReactIntl = require('react-intl');
 
 var assert = require('assert');
@@ -13,6 +14,8 @@ var sinon = require('sinon');
 var { shallow, mount } = require('enzyme');
 
 var TimeSelect = require('../src/TimeSelect');
+var HourInput = require('../src/HourInput');
+var MinuteInput = require('../src/MinuteInput');
 
 describe('TimeSelect', function() {
   it('is an element', function() {
@@ -132,36 +135,31 @@ describe('TimeSelect', function() {
         };
       });
 
-      it('should create 2 inputs', function() {
-        var timeSelect = shallow(<TimeSelect {...props}/>);
-        expect(timeSelect.find(Input)).to.have.length(2);
-      });
-
       it('should have a hours input', function() {
-        var timeSelect = shallow(<TimeSelect {...props}/>);
-        expect(timeSelect.find(Input).first().props().label).to.equal('Hours');
+        var timeSelect = mount(<TimeSelect {...props}/>);
+        expect(timeSelect.find(HourInput));
       });
 
       it('should have a minutes input', function() {
         var timeSelect = shallow(<TimeSelect {...props}/>);
-        expect(timeSelect.find(Input).at(1).props().label).to.equal('Minutes');
+        expect(timeSelect.find(MinuteInput));
       });
 
       it('should use current time as value', function() {
         var timeSelect = shallow(<TimeSelect {...props}/>);
-        expect(timeSelect.find(Input).first().props().value).to.equal(props.time.hours);
-        expect(timeSelect.find(Input).at(1).props().value).to.equal(props.time.minutes);
+        expect(timeSelect.find(HourInput).props().value).to.equal(props.time.hours);
+        expect(timeSelect.find(MinuteInput).props().value).to.equal(props.time.minutes);
       });
 
       it('fills the hours select box with 24 hours', function() {
-        var timeSelect = shallow(<TimeSelect {...props}/>);
-        expect(timeSelect.find(Input).first().children()).to.have.length(24);
+        var timeSelect = mount(<TimeSelect {...props}/>);
+        expect(timeSelect.find(HourInput).props().options).to.have.length(24);
       });
 
       it('fills the minutes select box with range from steps prop', function() {
         props.step = 5;
-        var timeSelect = shallow(<TimeSelect {...props}/>);
-        expect(timeSelect.find(Input).at(1).children()).to.have.length(12);
+        var timeSelect = mount(<TimeSelect {...props}/>);
+        expect(timeSelect.find(MinuteInput).props().options).to.have.length(12);
       });
     });
   });
@@ -190,7 +188,7 @@ describe('TimeSelect', function() {
       });
     });
 
-    it('will emit a date up if an option is chosen', function() {
+    it('will emit a time up if an option is chosen', function() {
       var handler = sinon.stub();
       var doc = TestUtils.renderIntoDocument(<TimeSelect onChange={handler} />);
       var node = TestUtils.findRenderedDOMComponentWithTag(doc, 'select');
@@ -201,22 +199,7 @@ describe('TimeSelect', function() {
         }
       });
 
-      sinon.assert.calledWith(handler, new Date(2015, 5, 6, 11, 30, 0, 0));
-    });
-
-    it('will use a passed in date for the values of days/months/years', function() {
-      var handler = sinon.stub();
-      var date = new Date(2016, 7, 8);
-      var doc = TestUtils.renderIntoDocument(<TimeSelect onChange={handler} value={date} />);
-      var node = TestUtils.findRenderedDOMComponentWithTag(doc, 'select');
-
-      TestUtils.Simulate.change(node, {
-        target: {
-          value: '14:30'
-        }
-      });
-
-      sinon.assert.calledWith(handler, new Date(2016, 7, 8, 14, 30, 0, 0));
+      sinon.assert.calledWith(handler, { hours: '11', minutes: '30' });
     });
 
     context('seperateHourMins', function() {
@@ -241,7 +224,7 @@ describe('TimeSelect', function() {
             }
           });
 
-          sinon.assert.calledWith(handler, { hours: '14' });
+          sinon.assert.calledWith(handler, { hours: '14', minutes: '55' });
         });
       });
 
@@ -257,7 +240,7 @@ describe('TimeSelect', function() {
             }
           });
 
-          sinon.assert.calledWith(handler, { minutes: '50' });
+          sinon.assert.calledWith(handler, { hours: '11', minutes: '50' });
         });
       });
     });


### PR DESCRIPTION
**What does this PR do? (please provide any background)**

Adds the capability to seperate the hours / minutes into their own dropdowns (as the dropdown was going to be too long with more specific minute step increases).

`seperateHourMins=true` -> Show hour dropdown and minute dropdown.
`seperateHourMins=false / default` -> Show hours and minutes as combined dropdown.


**What tests does this PR have?**
Updated unit tests.

**How can this be tested?**
To locally test this you will need to reference each repo's branch in the package.json. This is a bit of a pain, so I can show you on my machine if that's preferred.

https://github.com/holidayextras/tripapp-product-resorttransfers/pull/43/
https://github.com/holidayextras/react-date-time-group/pull/11

- Make sure times are updated and are passed into the url.
- Make sure dates are still correct.
- Make sure old behaviour is the same when the prop `seperateHourMins` is not passed in or is false.

**Any tech debt?**

No.

**Screenshots / Screencast**

https://cloudup.com/cib8W-R_f4F

**What gif best describes how you feel about this work?**